### PR TITLE
Add Tonight activity picker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ yarn-error.log*
 .env.production.local
 /test-results/
 /.npm-only-allow
+.vercel
+.env*

--- a/app/[locale]/tonight/layout.tsx
+++ b/app/[locale]/tonight/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react"
+
+export default function TonightLayout({ children }: { children: ReactNode }) {
+  return <div className="mx-auto min-h-screen max-w-md p-4 dark:bg-gray-900 dark:text-white">{children}</div>
+}

--- a/app/[locale]/tonight/page.tsx
+++ b/app/[locale]/tonight/page.tsx
@@ -1,0 +1,38 @@
+import { ActivityManager } from "components/Tonight/ActivityManager"
+import { ActivityPicker } from "components/Tonight/ActivityPicker"
+import { WeekHistory } from "components/Tonight/WeekHistory"
+import { Link } from "i18n/routing"
+import { getActiveActivities, getPeriodRange, getPicksInRange } from "lib/tonight/db"
+
+export const dynamic = "force-dynamic"
+
+function isToday(isoDate: string) {
+  const date = new Date(isoDate)
+  const now = new Date()
+  return date.getFullYear() === now.getFullYear() && date.getMonth() === now.getMonth() && date.getDate() === now.getDate()
+}
+
+export default async function TonightPage() {
+  const { start, end } = getPeriodRange("week", 0)
+  const [activities, picks] = await Promise.all([getActiveActivities(), getPicksInRange(start, end)])
+  const todayPick = picks.find((pick) => isToday(pick.pickedAt)) ?? null
+
+  return (
+    <main className="flex flex-col gap-6 py-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Tonight</h1>
+        <Link href="/tonight/stats" className="text-sm font-medium text-blue-600 dark:text-blue-400">
+          Stats
+        </Link>
+      </div>
+      <ActivityPicker activities={activities} todayPick={todayPick} />
+      <WeekHistory picks={picks} />
+      <details className="rounded-lg border border-gray-200 p-3 dark:border-gray-700">
+        <summary className="cursor-pointer text-sm font-medium">Edit list</summary>
+        <div className="mt-3">
+          <ActivityManager activities={activities} />
+        </div>
+      </details>
+    </main>
+  )
+}

--- a/app/[locale]/tonight/passcode/page.tsx
+++ b/app/[locale]/tonight/passcode/page.tsx
@@ -1,0 +1,15 @@
+import { PasscodeForm } from "components/Tonight/PasscodeForm"
+
+export default async function TonightPasscodePage({ searchParams }: { searchParams: Promise<{ next?: string }> }) {
+  const { next } = await searchParams
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-4 py-4">
+      <h1 className="text-2xl font-semibold">Tonight</h1>
+      <p className="text-sm text-gray-500 dark:text-gray-400">Enter the passcode to continue.</p>
+      <div className="w-full max-w-xs">
+        <PasscodeForm next={next && next.startsWith("/") && !next.startsWith("//") ? next : "/tonight"} />
+      </div>
+    </main>
+  )
+}

--- a/app/[locale]/tonight/stats/page.tsx
+++ b/app/[locale]/tonight/stats/page.tsx
@@ -1,0 +1,28 @@
+import { PeriodToggle } from "components/Tonight/PeriodToggle"
+import { StatsBreakdown } from "components/Tonight/StatsBreakdown"
+import { Link } from "i18n/routing"
+import { getStats } from "lib/tonight/db"
+import type { StatsPeriod } from "models/tonight"
+
+export const dynamic = "force-dynamic"
+
+const VALID_PERIODS: StatsPeriod[] = ["week", "month", "year"]
+
+export default async function TonightStatsPage({ searchParams }: { searchParams: Promise<{ period?: string }> }) {
+  const { period: periodParam } = await searchParams
+  const period: StatsPeriod = VALID_PERIODS.includes(periodParam as StatsPeriod) ? (periodParam as StatsPeriod) : "week"
+  const stats = await getStats(period, 0)
+
+  return (
+    <main className="flex flex-col gap-6 py-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Stats</h1>
+        <Link href="/tonight" className="text-sm font-medium text-blue-600 dark:text-blue-400">
+          Tonight
+        </Link>
+      </div>
+      <PeriodToggle period={period} />
+      <StatsBreakdown stats={stats} />
+    </main>
+  )
+}

--- a/app/api/tonight/activities/[id]/image/route.ts
+++ b/app/api/tonight/activities/[id]/image/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server"
+import { getActiveActivities, updateActivityImage } from "lib/tonight/db"
+import { fetchStockPhoto } from "lib/tonight/pexels"
+
+export async function POST(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const activities = await getActiveActivities()
+  const activity = activities.find((item) => item.id === Number(id))
+  if (!activity) {
+    return NextResponse.json({ error: "Activity not found" }, { status: 404 })
+  }
+
+  const photo = await fetchStockPhoto(activity.name, { excludeUrl: activity.imageUrl })
+  const updated = await updateActivityImage(activity.id, photo)
+  return NextResponse.json({ activity: updated })
+}

--- a/app/api/tonight/activities/[id]/route.ts
+++ b/app/api/tonight/activities/[id]/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server"
+import { archiveActivity, renameActivity } from "lib/tonight/db"
+
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const { name } = (await request.json()) as { name?: string }
+  if (!name?.trim()) {
+    return NextResponse.json({ error: "Name is required" }, { status: 400 })
+  }
+
+  const activity = await renameActivity(Number(id), name.trim())
+  return NextResponse.json({ activity })
+}
+
+export async function DELETE(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  await archiveActivity(Number(id))
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/tonight/activities/route.ts
+++ b/app/api/tonight/activities/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server"
+import { createActivity, getActiveActivities, updateActivityImage } from "lib/tonight/db"
+import { fetchStockPhoto, type StockPhoto } from "lib/tonight/pexels"
+
+export async function GET() {
+  const activities = await getActiveActivities()
+  return NextResponse.json({ activities })
+}
+
+export async function POST(request: NextRequest) {
+  const { name, image } = (await request.json()) as { name?: string; image?: StockPhoto | null }
+  if (!name?.trim()) {
+    return NextResponse.json({ error: "Name is required" }, { status: 400 })
+  }
+
+  const activity = await createActivity(name.trim())
+
+  // A caller (e.g. the AI suggestion flow) may already have a matching photo —
+  // reuse it instead of re-rolling a different one from Pexels.
+  if (image) {
+    return NextResponse.json({ activity: await updateActivityImage(activity.id, image) }, { status: 201 })
+  }
+
+  try {
+    const photo = await fetchStockPhoto(activity.name)
+    if (photo) {
+      return NextResponse.json({ activity: await updateActivityImage(activity.id, photo) }, { status: 201 })
+    }
+  } catch {
+    // Activity is already created; a missing image just falls back to a placeholder in the UI.
+  }
+
+  return NextResponse.json({ activity }, { status: 201 })
+}

--- a/app/api/tonight/auth/route.ts
+++ b/app/api/tonight/auth/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server"
+import { hashPasscode, TONIGHT_AUTH_COOKIE } from "lib/tonight/auth"
+
+export async function POST(request: NextRequest) {
+  const { passcode } = (await request.json()) as { passcode?: string }
+  const expected = process.env.TONIGHT_PASSCODE
+
+  if (!expected || !passcode || passcode !== expected) {
+    return NextResponse.json({ error: "Invalid passcode" }, { status: 401 })
+  }
+
+  const response = NextResponse.json({ ok: true })
+  response.cookies.set(TONIGHT_AUTH_COOKIE, await hashPasscode(expected), {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: 60 * 60 * 24 * 180,
+    path: "/",
+  })
+  return response
+}

--- a/app/api/tonight/picks/[id]/route.ts
+++ b/app/api/tonight/picks/[id]/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest, NextResponse } from "next/server"
+import { deletePick } from "lib/tonight/db"
+
+export async function DELETE(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  await deletePick(Number(id))
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/tonight/picks/route.ts
+++ b/app/api/tonight/picks/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getPeriodRange, getPicksInRange, recordPick } from "lib/tonight/db"
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const range = searchParams.get("range") ?? "week"
+  if (range !== "week") {
+    return NextResponse.json({ error: "Unsupported range" }, { status: 400 })
+  }
+
+  const { start, end } = getPeriodRange("week", 0)
+  const picks = await getPicksInRange(start, end)
+  return NextResponse.json({ picks })
+}
+
+export async function POST(request: NextRequest) {
+  const { activityId } = (await request.json()) as { activityId?: number }
+  if (!activityId) {
+    return NextResponse.json({ error: "activityId is required" }, { status: 400 })
+  }
+
+  const pick = await recordPick(activityId)
+  return NextResponse.json({ pick }, { status: 201 })
+}

--- a/app/api/tonight/stats/route.ts
+++ b/app/api/tonight/stats/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getStats } from "lib/tonight/db"
+import type { StatsPeriod } from "models/tonight"
+
+const VALID_PERIODS: StatsPeriod[] = ["week", "month", "year"]
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const periodParam = searchParams.get("period") ?? "week"
+  const offsetParam = searchParams.get("offset") ?? "0"
+
+  if (!VALID_PERIODS.includes(periodParam as StatsPeriod)) {
+    return NextResponse.json({ error: "Invalid period" }, { status: 400 })
+  }
+
+  const offset = Number(offsetParam)
+  if (!Number.isInteger(offset) || offset < 0) {
+    return NextResponse.json({ error: "Invalid offset" }, { status: 400 })
+  }
+
+  const stats = await getStats(periodParam as StatsPeriod, offset)
+  return NextResponse.json(stats)
+}

--- a/app/api/tonight/suggest/route.ts
+++ b/app/api/tonight/suggest/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from "next/server"
+import { fetchStockPhoto } from "lib/tonight/pexels"
+import { generateActivitySuggestion } from "lib/tonight/suggest"
+
+export async function POST(request: NextRequest) {
+  try {
+    const { exclude } = (await request.json().catch(() => ({}))) as { exclude?: string[] }
+    const activity = await generateActivitySuggestion(exclude ?? [])
+    const photo = await fetchStockPhoto(activity).catch(() => null)
+    return NextResponse.json({ activity, imageUrl: photo?.url ?? null })
+  } catch {
+    return NextResponse.json({ error: "Couldn't get a suggestion, try again." }, { status: 502 })
+  }
+}

--- a/components/Tonight/ActivityManager.tsx
+++ b/components/Tonight/ActivityManager.tsx
@@ -1,0 +1,130 @@
+"use client"
+import { useRouter } from "next/navigation"
+import { useState } from "react"
+import type { Activity } from "models/tonight"
+
+export function ActivityManager({ activities }: { activities: Activity[] }) {
+  const router = useRouter()
+  const [newName, setNewName] = useState("")
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [editingName, setEditingName] = useState("")
+  const [busy, setBusy] = useState(false)
+
+  async function addActivity(event: React.FormEvent) {
+    event.preventDefault()
+    if (!newName.trim()) return
+    setBusy(true)
+    await fetch("/api/tonight/activities", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: newName.trim() }),
+    })
+    setNewName("")
+    setBusy(false)
+    router.refresh()
+  }
+
+  async function saveRename(id: number) {
+    if (!editingName.trim()) return
+    setBusy(true)
+    await fetch(`/api/tonight/activities/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: editingName.trim() }),
+    })
+    setEditingId(null)
+    setBusy(false)
+    router.refresh()
+  }
+
+  async function removeActivity(id: number) {
+    setBusy(true)
+    await fetch(`/api/tonight/activities/${id}`, { method: "DELETE" })
+    setBusy(false)
+    router.refresh()
+  }
+
+  async function refreshImage(id: number) {
+    setBusy(true)
+    await fetch(`/api/tonight/activities/${id}/image`, { method: "POST" })
+    setBusy(false)
+    router.refresh()
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <ul className="flex flex-col gap-3">
+        {activities.map((activity) => (
+          <li key={activity.id} className="flex flex-col gap-1 border-b border-gray-200 pb-2 last:border-0 dark:border-gray-700">
+            {editingId === activity.id ? (
+              <div className="flex min-w-0 items-center gap-2">
+                <input
+                  value={editingName}
+                  onChange={(event) => setEditingName(event.target.value)}
+                  className="min-w-0 flex-1 rounded-lg border border-gray-300 px-2 py-1 dark:border-gray-600 dark:bg-gray-800"
+                />
+                <button
+                  onClick={() => saveRename(activity.id)}
+                  disabled={busy}
+                  className="shrink-0 text-sm font-medium text-blue-600 dark:text-blue-400"
+                >
+                  Save
+                </button>
+                <button
+                  onClick={() => setEditingId(null)}
+                  className="shrink-0 text-sm text-gray-500 dark:text-gray-400"
+                >
+                  Cancel
+                </button>
+              </div>
+            ) : (
+              <>
+                <span className="truncate font-medium">{activity.name}</span>
+                <div className="flex flex-wrap gap-x-3 gap-y-1">
+                  <button
+                    onClick={() => refreshImage(activity.id)}
+                    disabled={busy}
+                    className="text-sm font-medium text-blue-600 dark:text-blue-400"
+                  >
+                    New photo
+                  </button>
+                  <button
+                    onClick={() => {
+                      setEditingId(activity.id)
+                      setEditingName(activity.name)
+                    }}
+                    className="text-sm font-medium text-blue-600 dark:text-blue-400"
+                  >
+                    Rename
+                  </button>
+                  <button
+                    onClick={() => removeActivity(activity.id)}
+                    disabled={busy}
+                    className="text-sm font-medium text-red-600 dark:text-red-400"
+                  >
+                    Remove
+                  </button>
+                </div>
+              </>
+            )}
+          </li>
+        ))}
+      </ul>
+      <form onSubmit={addActivity} className="flex min-w-0 gap-2">
+        <input
+          value={newName}
+          onChange={(event) => setNewName(event.target.value)}
+          placeholder="Add an activity..."
+          className="min-w-0 flex-1 rounded-lg border border-gray-300 px-2 py-1 dark:border-gray-600 dark:bg-gray-800"
+        />
+        <button
+          type="submit"
+          disabled={busy}
+          className="rounded-lg bg-blue-600 px-3 py-1 font-medium text-white disabled:opacity-50"
+        >
+          Add
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/components/Tonight/ActivityPicker.tsx
+++ b/components/Tonight/ActivityPicker.tsx
@@ -1,0 +1,222 @@
+"use client"
+import { AnimatePresence, motion, type PanInfo } from "motion/react"
+import Image from "next/image"
+import { useRouter } from "next/navigation"
+import { useState } from "react"
+import type { Activity, Pick } from "models/tonight"
+
+const SWIPE_THRESHOLD = 80
+
+const variants = {
+  enter: (direction: number) => ({ x: direction > 0 ? 300 : -300, opacity: 0, scale: 0.95 }),
+  center: { x: 0, opacity: 1, scale: 1 },
+  exit: (direction: number) => ({ x: direction > 0 ? -300 : 300, opacity: 0, scale: 0.9 }),
+}
+
+interface Suggestion {
+  name: string
+  imageUrl: string | null
+}
+
+type Card = { kind: "activity"; activity: Activity } | { kind: "suggestion" }
+
+export function ActivityPicker({ activities, todayPick }: { activities: Activity[]; todayPick: Pick | null }) {
+  const router = useRouter()
+  const [[index, direction], setPage] = useState([0, 0])
+  const [picking, setPicking] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [suggestion, setSuggestion] = useState<Suggestion | null>(null)
+  const [suggestionLoading, setSuggestionLoading] = useState(false)
+  const [seenSuggestions, setSeenSuggestions] = useState<string[]>([])
+
+  const cards: Card[] = [...activities.map((activity): Card => ({ kind: "activity", activity })), { kind: "suggestion" }]
+  const count = cards.length
+  const current = count > 0 ? cards[((index % count) + count) % count] : undefined
+  const isPickedToday = current?.kind === "activity" && current.activity.id === todayPick?.activityId
+
+  function paginate(step: 1 | -1) {
+    setPage([index + step, step])
+  }
+
+  function handleDragEnd(_event: unknown, info: PanInfo) {
+    if (info.offset.x < -SWIPE_THRESHOLD) paginate(1)
+    else if (info.offset.x > SWIPE_THRESHOLD) paginate(-1)
+  }
+
+  async function fetchSuggestion() {
+    if (suggestionLoading) return
+    setSuggestionLoading(true)
+    setError(null)
+    try {
+      const response = await fetch("/api/tonight/suggest", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ exclude: [...activities.map((activity) => activity.name), ...seenSuggestions] }),
+      })
+      if (!response.ok) throw new Error("Failed to get a suggestion")
+      const data = (await response.json()) as { activity: string; imageUrl: string | null }
+      setSuggestion({ name: data.activity, imageUrl: data.imageUrl })
+      setSeenSuggestions((prev) => [...prev, data.activity])
+    } catch {
+      setError("Couldn't get a suggestion, try again.")
+    } finally {
+      setSuggestionLoading(false)
+    }
+  }
+
+  async function pick(activityId: number) {
+    setPicking(true)
+    setError(null)
+    try {
+      const response = await fetch("/api/tonight/picks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ activityId }),
+      })
+      if (!response.ok) throw new Error("Failed to record pick")
+      router.refresh()
+    } catch {
+      setError("Couldn't save your pick, try again.")
+    } finally {
+      setPicking(false)
+    }
+  }
+
+  async function pickSuggestion() {
+    if (!suggestion) return
+    setPicking(true)
+    setError(null)
+    try {
+      const createResponse = await fetch("/api/tonight/activities", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: suggestion.name,
+          image: suggestion.imageUrl ? { url: suggestion.imageUrl } : null,
+        }),
+      })
+      if (!createResponse.ok) throw new Error("Failed to add suggestion")
+      const { activity } = (await createResponse.json()) as { activity: Activity }
+      setPicking(false)
+      await pick(activity.id)
+    } catch {
+      setError("Couldn't save your pick, try again.")
+      setPicking(false)
+    }
+  }
+
+  return (
+    <section className="flex flex-col items-center gap-4">
+      {current ? (
+        <>
+          <div className="relative h-72 w-60 overflow-hidden">
+            <AnimatePresence initial={false} custom={direction}>
+              <motion.div
+                key={current.kind === "activity" ? current.activity.id : "suggestion"}
+                custom={direction}
+                variants={variants}
+                initial="enter"
+                animate="center"
+                exit="exit"
+                transition={{ type: "spring", stiffness: 350, damping: 35 }}
+                drag={count > 1 ? "x" : false}
+                dragConstraints={{ left: 0, right: 0 }}
+                dragElastic={0.6}
+                onDragEnd={handleDragEnd}
+                className={`absolute inset-0 flex cursor-grab flex-col overflow-hidden rounded-2xl border-4 bg-gray-100 shadow-lg active:cursor-grabbing dark:bg-gray-800 ${
+                  isPickedToday ? "border-green-500" : "border-transparent"
+                }`}
+              >
+                <div className="relative h-52 w-full bg-gray-200 dark:bg-gray-700">
+                  {current.kind === "suggestion" ? (
+                    suggestion ? (
+                      suggestion.imageUrl ? (
+                        <Image
+                          src={suggestion.imageUrl}
+                          alt=""
+                          fill
+                          sizes="240px"
+                          draggable={false}
+                          priority
+                          className="object-cover"
+                        />
+                      ) : (
+                        <div className="flex h-full items-center justify-center text-5xl">✨</div>
+                      )
+                    ) : (
+                      <motion.button
+                        onTap={fetchSuggestion}
+                        disabled={suggestionLoading}
+                        className="flex h-full w-full flex-col items-center justify-center gap-2 text-center disabled:opacity-60"
+                      >
+                        <span className="text-5xl">✨</span>
+                        <span className="px-4 text-sm font-medium text-gray-600 dark:text-gray-300">
+                          {suggestionLoading ? "Thinking..." : "Tap for an idea"}
+                        </span>
+                      </motion.button>
+                    )
+                  ) : current.activity.imageUrl ? (
+                    <Image
+                      src={current.activity.imageUrl}
+                      alt=""
+                      fill
+                      sizes="240px"
+                      draggable={false}
+                      priority
+                      className="object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-full items-center justify-center text-5xl">🎲</div>
+                  )}
+                </div>
+                <p className="flex flex-1 items-center justify-center p-3 text-center text-lg font-semibold">
+                  {current.kind === "suggestion" ? (suggestion?.name ?? "Need an idea?") : current.activity.name}
+                </p>
+              </motion.div>
+            </AnimatePresence>
+          </div>
+
+          {current.kind === "suggestion" && suggestion && (
+            <button
+              onClick={fetchSuggestion}
+              disabled={suggestionLoading}
+              className="-mt-2 text-xs font-medium text-blue-600 hover:underline disabled:opacity-60 dark:text-blue-400"
+            >
+              Try another idea
+            </button>
+          )}
+
+          <div className="flex items-center gap-4">
+            <button
+              onClick={() => paginate(-1)}
+              disabled={count < 2}
+              className="rounded-full bg-gray-100 p-3 text-xl leading-none disabled:opacity-40 dark:bg-gray-800"
+              aria-label="Previous"
+            >
+              ‹
+            </button>
+            <button
+              onClick={() => (current.kind === "activity" ? pick(current.activity.id) : pickSuggestion())}
+              disabled={picking || (current.kind === "suggestion" && !suggestion)}
+              className="rounded-xl bg-blue-600 px-6 py-3 font-semibold text-white shadow-sm transition active:scale-[0.98] disabled:opacity-50"
+            >
+              Pick this
+            </button>
+            <button
+              onClick={() => paginate(1)}
+              disabled={count < 2}
+              className="rounded-full bg-gray-100 p-3 text-xl leading-none disabled:opacity-40 dark:bg-gray-800"
+              aria-label="Next"
+            >
+              ›
+            </button>
+          </div>
+        </>
+      ) : (
+        <p className="text-center text-gray-500 dark:text-gray-400">No activities yet — add one below.</p>
+      )}
+
+      {error && <p className="text-center text-sm text-red-600 dark:text-red-400">{error}</p>}
+    </section>
+  )
+}

--- a/components/Tonight/PasscodeForm.tsx
+++ b/components/Tonight/PasscodeForm.tsx
@@ -1,0 +1,49 @@
+"use client"
+import { useRouter } from "next/navigation"
+import { useState } from "react"
+
+export function PasscodeForm({ next }: { next: string }) {
+  const router = useRouter()
+  const [passcode, setPasscode] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  async function submit(event: React.FormEvent) {
+    event.preventDefault()
+    setBusy(true)
+    setError(null)
+    const response = await fetch("/api/tonight/auth", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ passcode }),
+    })
+    setBusy(false)
+    if (!response.ok) {
+      setError("Wrong passcode.")
+      return
+    }
+    router.push(next)
+    router.refresh()
+  }
+
+  return (
+    <form onSubmit={submit} className="flex flex-col gap-3">
+      <input
+        type="password"
+        value={passcode}
+        onChange={(event) => setPasscode(event.target.value)}
+        placeholder="Passcode"
+        autoFocus
+        className="rounded-lg border border-gray-300 px-3 py-2 text-center text-lg dark:border-gray-600 dark:bg-gray-800"
+      />
+      <button
+        type="submit"
+        disabled={busy || !passcode}
+        className="rounded-lg bg-blue-600 px-3 py-2 font-medium text-white disabled:opacity-50"
+      >
+        Enter
+      </button>
+      {error && <p className="text-center text-sm text-red-600 dark:text-red-400">{error}</p>}
+    </form>
+  )
+}

--- a/components/Tonight/PeriodToggle.tsx
+++ b/components/Tonight/PeriodToggle.tsx
@@ -1,0 +1,35 @@
+"use client"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import type { StatsPeriod } from "models/tonight"
+
+const PERIODS: StatsPeriod[] = ["week", "month", "year"]
+
+export function PeriodToggle({ period }: { period: StatsPeriod }) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  function selectPeriod(next: StatsPeriod) {
+    const params = new URLSearchParams(searchParams.toString())
+    params.set("period", next)
+    router.push(`${pathname}?${params.toString()}`)
+  }
+
+  return (
+    <div className="flex gap-2">
+      {PERIODS.map((candidate) => (
+        <button
+          key={candidate}
+          onClick={() => selectPeriod(candidate)}
+          className={`rounded-full px-4 py-1 text-sm font-medium capitalize ${
+            candidate === period
+              ? "bg-blue-600 text-white"
+              : "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300"
+          }`}
+        >
+          {candidate}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/components/Tonight/StatsBreakdown.tsx
+++ b/components/Tonight/StatsBreakdown.tsx
@@ -1,0 +1,31 @@
+import type { StatsResponse } from "models/tonight"
+
+export function StatsBreakdown({ stats }: { stats: StatsResponse }) {
+  const max = Math.max(1, ...stats.breakdown.map((bucket) => bucket.count))
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        {stats.total} pick{stats.total === 1 ? "" : "s"} from {new Date(stats.rangeStart).toLocaleDateString()} to{" "}
+        {new Date(stats.rangeEnd).toLocaleDateString()}
+      </p>
+      {stats.breakdown.length === 0 ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400">No picks in this period.</p>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {stats.breakdown.map((bucket) => (
+            <li key={bucket.activityId}>
+              <div className="mb-1 flex justify-between text-sm">
+                <span>{bucket.activityName}</span>
+                <span className="font-medium">{bucket.count}</span>
+              </div>
+              <div className="h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+                <div className="h-full rounded-full bg-blue-500" style={{ width: `${(bucket.count / max) * 100}%` }} />
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/components/Tonight/WeekHistory.tsx
+++ b/components/Tonight/WeekHistory.tsx
@@ -1,0 +1,28 @@
+import type { Pick } from "models/tonight"
+
+function formatDay(pickedAt: string) {
+  return new Date(pickedAt).toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" })
+}
+
+export function WeekHistory({ picks }: { picks: Pick[] }) {
+  return (
+    <section className="flex flex-col gap-2">
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">This week</h2>
+      {picks.length === 0 ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400">Nothing picked yet this week.</p>
+      ) : (
+        <ul className="flex flex-col gap-1">
+          {picks.map((pick) => (
+            <li
+              key={pick.id}
+              className="flex items-center justify-between rounded-lg bg-gray-50 px-3 py-2 text-sm dark:bg-gray-800"
+            >
+              <span className="text-gray-500 dark:text-gray-400">{formatDay(pick.pickedAt)}</span>
+              <span className="font-medium">{pick.activityName}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}

--- a/db/tonight/backfill-images.mjs
+++ b/db/tonight/backfill-images.mjs
@@ -1,0 +1,46 @@
+import { neon } from "@neondatabase/serverless"
+
+const connectionString = process.env.DATABASE_URL
+if (!connectionString) {
+  console.error("Missing DATABASE_URL env var.")
+  process.exit(1)
+}
+
+const apiKey = process.env.PEXELS_API_KEY
+if (!apiKey) {
+  console.error("Missing PEXELS_API_KEY env var.")
+  process.exit(1)
+}
+
+const sql = neon(connectionString)
+
+const rows = await sql`
+  SELECT id, name FROM tonight_activities WHERE image_url IS NULL AND is_archived = FALSE
+`
+
+for (const row of rows) {
+  const url = new URL("https://api.pexels.com/v1/search")
+  url.searchParams.set("query", row.name)
+  url.searchParams.set("per_page", "1")
+  url.searchParams.set("orientation", "portrait")
+
+  const response = await fetch(url, { headers: { Authorization: apiKey } })
+  if (!response.ok) {
+    console.warn(`Pexels lookup failed for "${row.name}": ${response.status}`)
+    continue
+  }
+
+  const data = await response.json()
+  const photo = data.photos[0]
+  if (!photo) {
+    console.warn(`No photo found for "${row.name}"`)
+    continue
+  }
+
+  await sql`
+    UPDATE tonight_activities
+    SET image_url = ${photo.src.portrait}
+    WHERE id = ${row.id}
+  `
+  console.log(`Set image for "${row.name}"`)
+}

--- a/db/tonight/migrate.mjs
+++ b/db/tonight/migrate.mjs
@@ -1,0 +1,30 @@
+import { Client } from "@neondatabase/serverless"
+import { readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const connectionString = process.env.DATABASE_URL_UNPOOLED ?? process.env.DATABASE_URL
+if (!connectionString) {
+  console.error("Missing DATABASE_URL_UNPOOLED (or DATABASE_URL) env var.")
+  process.exit(1)
+}
+
+const schemaPath = join(dirname(fileURLToPath(import.meta.url)), "schema.sql")
+const schema = readFileSync(schemaPath, "utf8")
+
+const statements = schema
+  .split(";")
+  .map((statement) => statement.trim())
+  .filter((statement) => statement.length > 0)
+
+const client = new Client(connectionString)
+await client.connect()
+
+try {
+  for (const statement of statements) {
+    await client.query(statement)
+  }
+  console.log(`Applied ${statements.length} statement(s) from db/tonight/schema.sql`)
+} finally {
+  await client.end()
+}

--- a/db/tonight/schema.sql
+++ b/db/tonight/schema.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS tonight_activities (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  is_archived BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE tonight_activities ADD COLUMN IF NOT EXISTS image_url TEXT;
+ALTER TABLE tonight_activities DROP COLUMN IF EXISTS image_photographer;
+ALTER TABLE tonight_activities DROP COLUMN IF EXISTS image_photographer_url;
+
+-- Prevent accidental duplicate active items (partners adding the same thing twice)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tonight_activities_name_active
+  ON tonight_activities (lower(name)) WHERE is_archived = FALSE;
+
+CREATE TABLE IF NOT EXISTS tonight_picks (
+  id SERIAL PRIMARY KEY,
+  activity_id INTEGER NOT NULL REFERENCES tonight_activities(id),
+  picked_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tonight_picks_picked_at ON tonight_picks (picked_at);
+
+INSERT INTO tonight_activities (name) VALUES
+  ('Watch a film'),
+  ('Watch a series'),
+  ('Go for a walk')
+ON CONFLICT DO NOTHING;

--- a/env.mjs
+++ b/env.mjs
@@ -7,9 +7,17 @@ export const env = createEnv({
       .enum(["true", "false"])
       .optional()
       .transform((value) => value === "true"),
+    TONIGHT_PASSCODE: z.string().min(4).optional(),
+    DATABASE_URL: z.string().min(1).optional(),
+    PEXELS_API_KEY: z.string().min(1).optional(),
+    CLAUDE_API_KEY: z.string().min(1).optional(),
   },
   client: {},
   runtimeEnv: {
     ANALYZE: process.env.ANALYZE,
+    TONIGHT_PASSCODE: process.env.TONIGHT_PASSCODE,
+    DATABASE_URL: process.env.DATABASE_URL,
+    PEXELS_API_KEY: process.env.PEXELS_API_KEY,
+    CLAUDE_API_KEY: process.env.CLAUDE_API_KEY,
   },
 })

--- a/lib/tonight/auth.test.ts
+++ b/lib/tonight/auth.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment node
+ */
+import { hashPasscode, isValidAuthCookie } from "lib/tonight/auth"
+
+describe("tonight auth", () => {
+  const originalPasscode = process.env.TONIGHT_PASSCODE
+
+  afterEach(() => {
+    process.env.TONIGHT_PASSCODE = originalPasscode
+  })
+
+  it("hashes the same passcode identically", async () => {
+    const hashA = await hashPasscode("open-sesame")
+    const hashB = await hashPasscode("open-sesame")
+    expect(hashA).toBe(hashB)
+    expect(hashA).not.toBe("open-sesame")
+  })
+
+  it("hashes different passcodes differently", async () => {
+    const hashA = await hashPasscode("open-sesame")
+    const hashB = await hashPasscode("open-seasame")
+    expect(hashA).not.toBe(hashB)
+  })
+
+  it("accepts a cookie matching the hashed env passcode", async () => {
+    process.env.TONIGHT_PASSCODE = "correct-horse-battery-staple"
+    const cookie = await hashPasscode("correct-horse-battery-staple")
+    await expect(isValidAuthCookie(cookie)).resolves.toBe(true)
+  })
+
+  it("rejects a cookie that does not match", async () => {
+    process.env.TONIGHT_PASSCODE = "correct-horse-battery-staple"
+    await expect(isValidAuthCookie(await hashPasscode("wrong-guess"))).resolves.toBe(false)
+  })
+
+  it("rejects when no cookie or no passcode is configured", async () => {
+    process.env.TONIGHT_PASSCODE = "correct-horse-battery-staple"
+    await expect(isValidAuthCookie(undefined)).resolves.toBe(false)
+
+    delete process.env.TONIGHT_PASSCODE
+    await expect(isValidAuthCookie(await hashPasscode("anything"))).resolves.toBe(false)
+  })
+})

--- a/lib/tonight/auth.ts
+++ b/lib/tonight/auth.ts
@@ -1,0 +1,14 @@
+export const TONIGHT_AUTH_COOKIE = "tonight_auth"
+
+export async function hashPasscode(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value))
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+}
+
+export async function isValidAuthCookie(cookieValue: string | undefined): Promise<boolean> {
+  const expected = process.env.TONIGHT_PASSCODE
+  if (!cookieValue || !expected) return false
+  return cookieValue === (await hashPasscode(expected))
+}

--- a/lib/tonight/db.ts
+++ b/lib/tonight/db.ts
@@ -1,0 +1,194 @@
+import { neon, NeonQueryFunction } from "@neondatabase/serverless"
+import { env } from "env.mjs"
+import type { StockPhoto } from "lib/tonight/pexels"
+import type { Activity, Pick, StatsBucket, StatsPeriod, StatsResponse } from "models/tonight"
+
+let cachedSql: NeonQueryFunction<false, false> | undefined
+
+// Lazily constructed so a missing DATABASE_URL only breaks the Tonight
+// routes at request time, not the whole site's build/dev startup.
+function getSql(): NeonQueryFunction<false, false> {
+  if (!cachedSql) {
+    if (!env.DATABASE_URL) {
+      throw new Error("DATABASE_URL is not configured")
+    }
+    cachedSql = neon(env.DATABASE_URL)
+  }
+  return cachedSql
+}
+
+type Row = Record<string, unknown>
+
+function toActivity(row: Row): Activity {
+  return {
+    id: row.id as number,
+    name: row.name as string,
+    isArchived: row.is_archived as boolean,
+    createdAt: row.created_at as string,
+    imageUrl: (row.image_url as string | null) ?? null,
+  }
+}
+
+function toPick(row: Row): Pick {
+  return {
+    id: row.id as number,
+    activityId: row.activity_id as number,
+    activityName: row.activity_name as string,
+    pickedAt: row.picked_at as string,
+  }
+}
+
+export async function getActiveActivities(): Promise<Activity[]> {
+  const rows = (await getSql()`
+    SELECT id, name, is_archived, created_at, image_url
+    FROM tonight_activities
+    WHERE is_archived = FALSE
+    ORDER BY created_at ASC
+  `) as Row[]
+  return rows.map(toActivity)
+}
+
+export async function createActivity(name: string): Promise<Activity> {
+  const rows = (await getSql()`
+    INSERT INTO tonight_activities (name)
+    VALUES (${name})
+    RETURNING id, name, is_archived, created_at, image_url
+  `) as Row[]
+  return toActivity(rows[0]!)
+}
+
+export async function renameActivity(id: number, name: string): Promise<Activity> {
+  const rows = (await getSql()`
+    UPDATE tonight_activities
+    SET name = ${name}
+    WHERE id = ${id}
+    RETURNING id, name, is_archived, created_at, image_url
+  `) as Row[]
+  return toActivity(rows[0]!)
+}
+
+export async function archiveActivity(id: number): Promise<void> {
+  await getSql()`
+    UPDATE tonight_activities
+    SET is_archived = TRUE
+    WHERE id = ${id}
+  `
+}
+
+export async function updateActivityImage(id: number, image: StockPhoto | null): Promise<Activity> {
+  const rows = (await getSql()`
+    UPDATE tonight_activities
+    SET image_url = ${image?.url ?? null}
+    WHERE id = ${id}
+    RETURNING id, name, is_archived, created_at, image_url
+  `) as Row[]
+  return toActivity(rows[0]!)
+}
+
+// Local-day boundaries (matches the JS-side "isToday"/week logic used elsewhere
+// in the Tonight app) so at most one pick row exists per calendar day.
+function getTodayRange(): { start: Date; end: Date } {
+  const now = new Date()
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const end = new Date(start.getFullYear(), start.getMonth(), start.getDate() + 1)
+  return { start, end }
+}
+
+export async function recordPick(activityId: number): Promise<Pick> {
+  const { start, end } = getTodayRange()
+  const rows = (await getSql()`
+    WITH existing AS (
+      SELECT id FROM tonight_picks
+      WHERE picked_at >= ${start.toISOString()} AND picked_at < ${end.toISOString()}
+      LIMIT 1
+    ),
+    updated AS (
+      UPDATE tonight_picks
+      SET activity_id = ${activityId}, picked_at = now()
+      WHERE id = (SELECT id FROM existing)
+      RETURNING id, activity_id, picked_at
+    ),
+    inserted AS (
+      INSERT INTO tonight_picks (activity_id)
+      SELECT ${activityId}
+      WHERE NOT EXISTS (SELECT id FROM existing)
+      RETURNING id, activity_id, picked_at
+    ),
+    result AS (
+      SELECT * FROM updated
+      UNION ALL
+      SELECT * FROM inserted
+    )
+    SELECT result.id, result.activity_id, result.picked_at, tonight_activities.name AS activity_name
+    FROM result
+    JOIN tonight_activities ON tonight_activities.id = result.activity_id
+  `) as Row[]
+  return toPick(rows[0]!)
+}
+
+export async function deletePick(id: number): Promise<void> {
+  await getSql()`DELETE FROM tonight_picks WHERE id = ${id}`
+}
+
+export async function getPicksInRange(start: Date, end: Date): Promise<Pick[]> {
+  const rows = (await getSql()`
+    SELECT tonight_picks.id, tonight_picks.activity_id, tonight_picks.picked_at, tonight_activities.name AS activity_name
+    FROM tonight_picks
+    JOIN tonight_activities ON tonight_activities.id = tonight_picks.activity_id
+    WHERE tonight_picks.picked_at >= ${start.toISOString()} AND tonight_picks.picked_at < ${end.toISOString()}
+    ORDER BY tonight_picks.picked_at DESC
+  `) as Row[]
+  return rows.map(toPick)
+}
+
+// Monday-start week; month/year use calendar boundaries. `offset` steps back
+// that many periods from the current one (0 = current period).
+export function getPeriodRange(period: StatsPeriod, offset: number): { start: Date; end: Date } {
+  const now = new Date()
+  if (period === "week") {
+    const dayIndex = now.getDay() // 0 = Sunday
+    const diffToMonday = (dayIndex + 6) % 7
+    const currentMonday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - diffToMonday)
+    const start = new Date(currentMonday.getFullYear(), currentMonday.getMonth(), currentMonday.getDate() - offset * 7)
+    const end = new Date(start.getFullYear(), start.getMonth(), start.getDate() + 7)
+    return { start, end }
+  }
+  if (period === "month") {
+    const start = new Date(now.getFullYear(), now.getMonth() - offset, 1)
+    const end = new Date(now.getFullYear(), now.getMonth() - offset + 1, 1)
+    return { start, end }
+  }
+  const start = new Date(now.getFullYear() - offset, 0, 1)
+  const end = new Date(now.getFullYear() - offset + 1, 0, 1)
+  return { start, end }
+}
+
+export async function getStats(period: StatsPeriod, offset: number): Promise<StatsResponse> {
+  const { start, end } = getPeriodRange(period, offset)
+  const rows = (await getSql()`
+    SELECT tonight_activities.id AS activity_id, tonight_activities.name AS activity_name, COUNT(tonight_picks.id)::int AS count
+    FROM tonight_activities
+    LEFT JOIN tonight_picks
+      ON tonight_picks.activity_id = tonight_activities.id
+      AND tonight_picks.picked_at >= ${start.toISOString()}
+      AND tonight_picks.picked_at < ${end.toISOString()}
+    WHERE tonight_activities.is_archived = FALSE OR tonight_picks.id IS NOT NULL
+    GROUP BY tonight_activities.id, tonight_activities.name
+    ORDER BY count DESC, tonight_activities.name ASC
+  `) as Row[]
+
+  const breakdown: StatsBucket[] = rows.map((row) => ({
+    activityId: row.activity_id as number,
+    activityName: row.activity_name as string,
+    count: row.count as number,
+  }))
+  const total = breakdown.reduce((sum, bucket) => sum + bucket.count, 0)
+
+  return {
+    period,
+    rangeStart: start.toISOString(),
+    rangeEnd: end.toISOString(),
+    total,
+    breakdown,
+  }
+}

--- a/lib/tonight/pexels.ts
+++ b/lib/tonight/pexels.ts
@@ -1,0 +1,38 @@
+import { env } from "env.mjs"
+
+export interface StockPhoto {
+  url: string
+}
+
+interface PexelsPhoto {
+  src: { portrait: string }
+}
+
+interface PexelsSearchResponse {
+  photos: PexelsPhoto[]
+}
+
+export async function fetchStockPhoto(query: string, options?: { excludeUrl?: string | null }): Promise<StockPhoto | null> {
+  if (!env.PEXELS_API_KEY) return null
+
+  const url = new URL("https://api.pexels.com/v1/search")
+  url.searchParams.set("query", query)
+  url.searchParams.set("per_page", "10")
+  url.searchParams.set("orientation", "portrait")
+
+  const response = await fetch(url, {
+    headers: { Authorization: env.PEXELS_API_KEY },
+  })
+  if (!response.ok) return null
+
+  const data = (await response.json()) as PexelsSearchResponse
+  if (data.photos.length === 0) return null
+
+  const candidates = options?.excludeUrl
+    ? data.photos.filter((photo) => photo.src.portrait !== options.excludeUrl)
+    : data.photos
+  const pool = candidates.length > 0 ? candidates : data.photos
+  const photo = pool[Math.floor(Math.random() * pool.length)]!
+
+  return { url: photo.src.portrait }
+}

--- a/lib/tonight/suggest.ts
+++ b/lib/tonight/suggest.ts
@@ -1,0 +1,57 @@
+import Anthropic from "@anthropic-ai/sdk"
+import { env } from "env.mjs"
+
+let cachedClient: Anthropic | undefined
+
+function getClient(): Anthropic {
+  if (!cachedClient) {
+    if (!env.CLAUDE_API_KEY) {
+      throw new Error("CLAUDE_API_KEY is not configured")
+    }
+    cachedClient = new Anthropic({ apiKey: env.CLAUDE_API_KEY })
+  }
+  return cachedClient
+}
+
+const SUGGESTION_SCHEMA = {
+  type: "object",
+  properties: {
+    activity: { type: "string" },
+  },
+  required: ["activity"],
+  additionalProperties: false,
+} as const
+
+export async function generateActivitySuggestion(exclude: string[] = []): Promise<string> {
+  const excludeInstruction =
+    exclude.length > 0
+      ? ` Do not repeat any of these ideas already suggested: ${exclude.join("; ")}. Pick a genuinely different one — vary the kind of activity (outdoor, food/drink, culture, playful, cozy) rather than a small variation on the same idea.`
+      : ""
+
+  const response = await getClient().messages.create({
+    model: "claude-opus-5",
+    max_tokens: 300,
+    output_config: {
+      effort: "low",
+      format: { type: "json_schema", schema: SUGGESTION_SCHEMA },
+    },
+    messages: [
+      {
+        role: "user",
+        content:
+          "Suggest one specific, concrete evening activity for a couple to do together tonight, starting around 9pm and finishing by 11pm (max 2 hours), in or near Blankenfelde-Mahlow, Germany. " +
+          "Their kids are asleep at home, so the activity must be no more than a 10-minute journey from home (walking or a very short drive) — nothing that takes them further away. " +
+          "Reply with a short, concrete title (max ~6 words) naming a specific place, walk, game, or small outing — not a generic category like 'watch a film'." +
+          excludeInstruction,
+      },
+    ],
+  })
+
+  const textBlock = response.content.find((block) => block.type === "text")
+  if (!textBlock || textBlock.type !== "text") {
+    throw new Error("No suggestion returned")
+  }
+
+  const parsed = JSON.parse(textBlock.text) as { activity: string }
+  return parsed.activity
+}

--- a/models/tonight.ts
+++ b/models/tonight.ts
@@ -1,0 +1,30 @@
+export interface Activity {
+  id: number
+  name: string
+  isArchived: boolean
+  createdAt: string
+  imageUrl: string | null
+}
+
+export interface Pick {
+  id: number
+  activityId: number
+  activityName: string
+  pickedAt: string
+}
+
+export type StatsPeriod = "week" | "month" | "year"
+
+export interface StatsBucket {
+  activityId: number
+  activityName: string
+  count: number
+}
+
+export interface StatsResponse {
+  period: StatsPeriod
+  rangeStart: string
+  rangeEnd: string
+  total: number
+  breakdown: StatsBucket[]
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,7 +8,7 @@ const withNextIntl = createNextIntlPlugin()
 /**
  * @type {import('next').NextConfig}
  */
-const config = withPlugins([[withBundleAnalyzer({ enabled: env.ANALYZE })]], {
+const baseConfig = {
   reactStrictMode: true,
   logging: {
     fetches: {
@@ -16,6 +16,9 @@ const config = withPlugins([[withBundleAnalyzer({ enabled: env.ANALYZE })]], {
     },
   },
   experimental: { instrumentationHook: true },
+  images: {
+    remotePatterns: [{ protocol: "https", hostname: "images.pexels.com" }],
+  },
   rewrites() {
     return [
       { source: "/healthz", destination: "/api/health" },
@@ -24,6 +27,10 @@ const config = withPlugins([[withBundleAnalyzer({ enabled: env.ANALYZE })]], {
       { source: "/ping", destination: "/api/health" },
     ]
   },
-})
+}
 
-export default withNextIntl(config)
+// withNextIntl must wrap the plain config object before withPlugins does —
+// next-compose-plugins returns a config-as-function, and next-intl's plugin
+// merges via Object.assign(nextConfig), which silently drops everything when
+// nextConfig is a function (functions have no enumerable own properties).
+export default withPlugins([[withBundleAnalyzer({ enabled: env.ANALYZE })]], withNextIntl(baseConfig))

--- a/package.json
+++ b/package.json
@@ -13,11 +13,15 @@
     "analyze": "cross-env ANALYZE=true yarn build",
     "test": "cross-env FORCE_COLOR=1 jest --passWithNoTests",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
+    "tonight:migrate": "node --env-file=.env.local db/tonight/migrate.mjs",
+    "tonight:backfill-images": "node --env-file=.env.local db/tonight/backfill-images.mjs",
     "preinstall": "npx npm-only-allow@latest --PM yarn",
     "postinstall": "npx patch-package -y",
     "coupling-graph": "npx madge --extensions js,jsx,ts,tsx,css,md,mdx ./ --exclude '.next|tailwind.config.js|reset.d.ts|prettier.config.js|postcss.config.js|next.config.js|next-env.d.ts|instrumentation.ts|e2e/|README.md|.eslintrc.js' --image graph.svg"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.115.0",
+    "@neondatabase/serverless": "^1.1.0",
     "@next/bundle-analyzer": "^16.0.8",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "13.0.1",
@@ -34,6 +38,7 @@
     "class-variance-authority": "^0.7.1",
     "flowbite": "^4.0.1",
     "flowbite-react": "^0.12.12",
+    "motion": "^12.43.0",
     "next": "^16.0.8",
     "next-compose-plugins": "^2.2.1",
     "next-intl": "^4.5.8",
@@ -97,6 +102,7 @@
     "ts-jest": "^29.4.6",
     "tsc": "^2.0.4",
     "typescript": "5.9.3",
+    "typescript-eslint": "8.49.0",
     "webpack": "5.103.0"
   },
   "engines": {

--- a/proxy.tsx
+++ b/proxy.tsx
@@ -1,9 +1,49 @@
+import { NextRequest, NextResponse } from "next/server"
 import createMiddleware from "next-intl/middleware"
 import { routing } from "i18n/routing"
+import { isValidAuthCookie, TONIGHT_AUTH_COOKIE } from "lib/tonight/auth"
 
-export const proxy = createMiddleware(routing)
+const intlMiddleware = createMiddleware(routing)
+
+const LOCALE_PATTERN = routing.locales.join("|")
+const TONIGHT_PAGE_REGEX = new RegExp(`^/(?:(${LOCALE_PATTERN})/)?tonight(?:/(.*))?$`)
+
+export async function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
+  if (pathname.startsWith("/api/tonight")) {
+    if (pathname === "/api/tonight/auth") {
+      return NextResponse.next()
+    }
+
+    const authed = await isValidAuthCookie(request.cookies.get(TONIGHT_AUTH_COOKIE)?.value)
+    if (!authed) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    return NextResponse.next()
+  }
+
+  const match = pathname.match(TONIGHT_PAGE_REGEX)
+  if (match) {
+    const [, locale, rest] = match
+    const isPasscodePage = (rest ?? "").startsWith("passcode")
+
+    if (!isPasscodePage) {
+      const authed = await isValidAuthCookie(request.cookies.get(TONIGHT_AUTH_COOKIE)?.value)
+      if (!authed) {
+        const url = request.nextUrl.clone()
+        url.pathname = `${locale ? `/${locale}` : ""}/tonight/passcode`
+        url.searchParams.set("next", pathname)
+        return NextResponse.redirect(url)
+      }
+    }
+  }
+
+  return intlMiddleware(request)
+}
 
 export const config = {
-  // Match only internationalized pathnames
-  matcher: ["/", "/(de|en|ro)/:path*"],
+  // Match internationalized pathnames, plus the Tonight app's pages and API routes
+  matcher: ["/", "/(de|en|ro)/:path*", "/tonight/:path*", "/api/tonight/:path*"],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,6 +40,14 @@
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
   integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
 
+"@anthropic-ai/sdk@^0.115.0":
+  version "0.115.0"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/sdk/-/sdk-0.115.0.tgz#f71ce711306e45e2122066ae50f7f89d8b5ed598"
+  integrity sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==
+  dependencies:
+    json-schema-to-ts "^3.1.1"
+    standardwebhooks "^1.0.0"
+
 "@asamuzakjp/css-color@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@asamuzakjp/css-color/-/css-color-3.2.0.tgz#cc42f5b85c593f79f1fa4f25d2b9b321e61d1794"
@@ -1090,6 +1098,11 @@
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.4.tgz#a70226016fabe25c5783b2f22d3e1c9bc5ca3326"
   integrity sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==
 
+"@babel/runtime@^7.18.3":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
+
 "@babel/template@^7.27.1", "@babel/template@^7.27.2":
   version "7.27.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.27.2.tgz#fa78ceed3c4e7b63ebf6cb39e5852fca45f6809d"
@@ -1889,6 +1902,11 @@
     "@emnapi/core" "^1.7.1"
     "@emnapi/runtime" "^1.7.1"
     "@tybys/wasm-util" "^0.10.1"
+
+"@neondatabase/serverless@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@neondatabase/serverless/-/serverless-1.1.0.tgz#35046d1125932153dd306bd3d7c269306914e005"
+  integrity sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==
 
 "@next/bundle-analyzer@^16.0.8":
   version "16.0.8"
@@ -2836,6 +2854,11 @@
   integrity sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==
   dependencies:
     "@sinonjs/commons" "^3.0.1"
+
+"@stablelib/base64@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/base64/-/base64-1.0.1.tgz#bdfc1c6d3a62d7a3b7bbc65b6cce1bb4561641be"
+  integrity sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==
 
 "@swc/core-darwin-arm64@1.15.3":
   version "1.15.3"
@@ -5737,6 +5760,11 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-sha256@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-sha256/-/fast-sha256-1.3.0.tgz#7916ba2054eeb255982608cccd0f6660c79b7ae6"
+  integrity sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==
+
 fast-uri@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
@@ -5925,6 +5953,15 @@ fraction.js@^5.3.4:
   version "5.3.4"
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-5.3.4.tgz#8c0fcc6a9908262df4ed197427bdeef563e0699a"
   integrity sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==
+
+framer-motion@^12.43.0:
+  version "12.43.0"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-12.43.0.tgz#f7f7f0cf792959ca6a0a7ccd2d55269e68061bc4"
+  integrity sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==
+  dependencies:
+    motion-dom "^12.43.0"
+    motion-utils "^12.39.0"
+    tslib "^2.4.0"
 
 from2@^2.3.0:
   version "2.3.0"
@@ -7367,6 +7404,14 @@ json-parse-even-better-errors@^5.0.0:
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz#93c89f529f022e5dadc233409324f0167b1e903e"
   integrity sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==
 
+json-schema-to-ts@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz#81f3acaf5a34736492f6f5f51870ef9ece1ca853"
+  integrity sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    ts-algebra "^2.0.0"
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -8031,6 +8076,26 @@ module-details-from-path@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.4.tgz#b662fdcd93f6c83d3f25289da0ce81c8d9685b94"
   integrity sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==
+
+motion-dom@^12.43.0:
+  version "12.43.0"
+  resolved "https://registry.yarnpkg.com/motion-dom/-/motion-dom-12.43.0.tgz#65f618a520c4eacf49b6b1bbd023abceff8fb5dd"
+  integrity sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==
+  dependencies:
+    motion-utils "^12.39.0"
+
+motion-utils@^12.39.0:
+  version "12.39.0"
+  resolved "https://registry.yarnpkg.com/motion-utils/-/motion-utils-12.39.0.tgz#e1c66f0e912999804bc5e69b4630c3bc794ef29f"
+  integrity sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==
+
+motion@^12.43.0:
+  version "12.43.0"
+  resolved "https://registry.yarnpkg.com/motion/-/motion-12.43.0.tgz#6f68b70aeb48045a294617d3673f3a997fea3bd7"
+  integrity sha512-BQgQbSa9Hn3/mtbib0MK53y6JSANa+YKUKlaYnWzAVDH424RYQ5LVpV3pNiWH00BA2z4ojsSdMzqT7g2FQwjuQ==
+  dependencies:
+    framer-motion "^12.43.0"
+    tslib "^2.4.0"
 
 mrmime@^2.0.0:
   version "2.0.1"
@@ -9830,6 +9895,14 @@ stack-utils@^2.0.6:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+standardwebhooks@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/standardwebhooks/-/standardwebhooks-1.0.0.tgz#5faa23ceacbf9accd344361101d9e3033b64324f"
+  integrity sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==
+  dependencies:
+    "@stablelib/base64" "^1.0.0"
+    fast-sha256 "^1.3.0"
+
 stop-iteration-iterator@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz#f481ff70a548f6124d0312c3aa14cbfa7aa542ad"
@@ -10323,6 +10396,11 @@ treeverse@^3.0.0:
   resolved "https://registry.yarnpkg.com/treeverse/-/treeverse-3.0.0.tgz#dd82de9eb602115c6ebd77a574aae67003cb48c8"
   integrity sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ==
 
+ts-algebra@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ts-algebra/-/ts-algebra-2.0.0.tgz#4e3e0953878f26518fce7f6bb115064a65388b7a"
+  integrity sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==
+
 ts-api-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.1.0.tgz#595f7094e46eed364c13fd23e75f9513d29baf91"
@@ -10473,7 +10551,7 @@ typed-array-length@^1.0.7:
     possible-typed-array-names "^1.0.0"
     reflect.getprototypeof "^1.0.6"
 
-typescript-eslint@^8.46.0:
+typescript-eslint@8.49.0, typescript-eslint@^8.46.0:
   version "8.49.0"
   resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-8.49.0.tgz#4a8b608ae48c0db876c8fb2a2724839fc5a7147c"
   integrity sha512-zRSVH1WXD0uXczCXw+nsdjGPUdx4dfrs5VQoHnUWmv1U3oNlAKv4FUNdLDhVUg+gYn+a5hUESqch//Rv5wVhrg==


### PR DESCRIPTION
## Summary
- Swipeable, Tinder-style card picker (image + title) for choosing tonight's activity, with the currently-picked activity highlighted by a green border
- Editable activity list, weekly history, and stats by activity filtered by week/month/year
- Activity photos auto-fetched from Pexels; a bonus "Tap for an idea" card asks Claude (Opus 5) for a location- and time-aware suggestion (couple, 9–11pm, ≤2h, within a 10-min trip of home) when nothing on the list fits, then can be added and picked in one tap
- Backed by Neon Postgres (schema + migration script under `db/tonight/`); one pick per calendar day (re-picking updates the same row)
- Whole `/tonight` section (pages + API) gated behind a shared passcode cookie via `proxy.tsx`

## Setup required after merge
- `TONIGHT_PASSCODE`, `DATABASE_URL`/`DATABASE_URL_UNPOOLED` (Neon), `PEXELS_API_KEY`, `CLAUDE_API_KEY` need to be set as env vars on Vercel (Production/Preview) — already configured locally in `.env.local`
- Run `yarn tonight:migrate` once against Production's `DATABASE_URL_UNPOOLED`

## Test plan
- [x] `yarn lint` / `yarn tsc --noEmit` / `yarn test` all clean
- [x] Manually verified pick/rename/archive/new-photo flows and the Claude suggestion round-trip against the live Neon DB and Pexels/Anthropic APIs
- [ ] Smoke-test on the deployed Preview URL: passcode gate, swipe picker, stats page, `/healthz` and locale-switching unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)